### PR TITLE
geolocation. sintaiyo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { Sekki72 } from './components/Sekki72';
 import { TimeSystem } from './components/TimeSystem';
 import { Rokuyo } from './components/Rokuyo';
 import { LunarCalendar } from './components/LunarCalendar';
+import { CurrentLocationDisplay } from './components/CurrentLocationDisplay';
 import { useEdoTime } from './hooks/useEdoTime';
 
 /** トップページ（江戸ごよみメイン表示） */
@@ -33,6 +34,7 @@ function TopPage() {
       <TimeSystem data={data} />
       <Rokuyo data={data} />
       <LunarCalendar data={data} />
+      <CurrentLocationDisplay data={data} />
     </AppLayout>
   );
 }

--- a/src/components/CurrentLocationDisplay.module.css
+++ b/src/components/CurrentLocationDisplay.module.css
@@ -1,0 +1,39 @@
+.container {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.label {
+  font-size: 0.875rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+}
+
+.value {
+  font-size: 1rem;
+  color: #1a1a1a;
+  font-weight: 400;
+}
+
+.noLocation {
+  font-size: 0.875rem;
+  color: #888;
+}
+
+.placeName {
+  font-size: 0.875rem;
+  color: #333;
+  margin-top: 0.25rem;
+}
+
+.credit {
+  font-size: 0.7rem;
+  color: #888;
+  margin-top: 0.5rem;
+}
+
+.credit a {
+  color: #666;
+}

--- a/src/components/CurrentLocationDisplay.tsx
+++ b/src/components/CurrentLocationDisplay.tsx
@@ -1,0 +1,81 @@
+/**
+ * 現在位置表示コンポーネント
+ * Current Location Display Component
+ *
+ * 不定時法などの計算に使用している緯度・経度（および逆ジオコーディングで取得した地名）を表示する。
+ * Footer と月齢表示ブロックの間に配置する。
+ *
+ * Displays the latitude and longitude used for calculations (and optionally place name from reverse geocoding).
+ * Placed between the moon age block and the footer.
+ */
+
+import { useState, useEffect } from 'react';
+import type { EdoTimeData } from '../core/types';
+import { reverseGeocode } from '../utils/reverseGeocode';
+import styles from './CurrentLocationDisplay.module.css';
+
+interface CurrentLocationDisplayProps {
+  /** 江戸時間データ（location は useEdoTime が付与）/ Edo time data (location set by useEdoTime) */
+  data: EdoTimeData;
+}
+
+function formatLatLon(lat: number, lon: number): string {
+  const latDir = lat >= 0 ? 'N' : 'S';
+  const lonDir = lon >= 0 ? 'E' : 'W';
+  return `緯度 ${Math.abs(lat).toFixed(4)}°${latDir} / 経度 ${Math.abs(lon).toFixed(4)}°${lonDir}`;
+}
+
+type PlaceNameState = { status: 'idle' } | { status: 'loading' } | { status: 'ok'; name: string } | { status: 'error' };
+
+/**
+ * 現在位置表示コンポーネント
+ * Current location display component
+ */
+export function CurrentLocationDisplay({ data }: CurrentLocationDisplayProps) {
+  const loc = data.location;
+  const [placeNameState, setPlaceNameState] = useState<PlaceNameState>({ status: 'idle' });
+
+  useEffect(() => {
+    if (!loc) {
+      setPlaceNameState({ status: 'idle' });
+      return;
+    }
+
+    let cancelled = false;
+    setPlaceNameState({ status: 'loading' });
+
+    reverseGeocode(loc.lat, loc.lon)
+      .then((name) => {
+        if (cancelled) return;
+        setPlaceNameState(name != null ? { status: 'ok', name } : { status: 'error' });
+      })
+      .catch(() => {
+        if (!cancelled) setPlaceNameState({ status: 'error' });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loc?.lat, loc?.lon]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.label}>現在位置</div>
+      {loc ? (
+        <>
+          <div className={styles.value}>{formatLatLon(loc.lat, loc.lon)}</div>
+          <div className={styles.placeName}>
+            {(placeNameState.status === 'idle' || placeNameState.status === 'loading') && '地名を取得中…'}
+            {placeNameState.status === 'ok' && placeNameState.name}
+            {placeNameState.status === 'error' && '地名を取得できません'}
+          </div>
+          <p className={styles.credit}>
+            地名表示: <a href="https://www.bigdatacloud.com/" target="_blank" rel="noopener noreferrer">BigDataCloud</a>
+          </p>
+        </>
+      ) : (
+        <div className={styles.noLocation}>位置情報なし</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TemporalTimeCircle.module.css
+++ b/src/components/TemporalTimeCircle.module.css
@@ -48,6 +48,20 @@
   margin: 0.25rem 0;
 }
 
+.solarNoonNote {
+  font-size: 0.75rem;
+  color: #666;
+  margin: 0.5rem 0 0;
+  line-height: 1.4;
+}
+
+.solarNoonSub {
+  display: block;
+  font-size: 0.7rem;
+  color: #999;
+  margin-top: 0.2rem;
+}
+
 @media (max-width: 768px) {
   .container {
     margin: 1rem 0;

--- a/src/components/TemporalTimeCircle.tsx
+++ b/src/components/TemporalTimeCircle.tsx
@@ -37,7 +37,12 @@ interface TemporalTimeCircleProps {
  * @returns 円形時計の表示要素 / Circular clock display element
  */
 export function TemporalTimeCircle({ data }: TemporalTimeCircleProps) {
-  const { temporalTime, akeMutsu, kureMutsu, currentTime, sunrise, sunset, noonForCircle } = data;
+  const { temporalTime, akeMutsu, kureMutsu, currentTime, sunrise, sunset, noonForCircle, solarNoon, location: loc } = data;
+
+  const solarNoonText =
+    loc?.tz != null
+      ? solarNoon.toLocaleString('ja-JP', { timeZone: loc.tz, hour: '2-digit', minute: '2-digit', hour12: false })
+      : `${String(solarNoon.getHours()).padStart(2, '0')}:${String(solarNoon.getMinutes()).padStart(2, '0')}`;
 
   // セグメントのレイアウト（昼・夜の扇形の角度）は日出・日落の「時刻」が変わるときだけ再計算する
   // 正午はコアが返す noonForCircle を使い、地点・タイムゾーンが変わっても角度が一貫するようにする
@@ -46,7 +51,7 @@ export function TemporalTimeCircle({ data }: TemporalTimeCircleProps) {
     const centerX = 200;
     const centerY = 200;
 
-    const { akeMutsuAngle, kureMutsuAngle } = calculateAkeKureAngles(sunrise, sunset, noonForCircle);
+    const { akeMutsuAngle, kureMutsuAngle } = calculateAkeKureAngles(akeMutsu, kureMutsu, noonForCircle);
     log('TemporalTimeCircle:segmentLayout', {
       sunrise: sunrise.getTime(),
       sunriseISO: sunrise.toISOString(),
@@ -486,6 +491,13 @@ export function TemporalTimeCircle({ data }: TemporalTimeCircleProps) {
           </g>
         </svg>
       </div>
+      <p
+        className={styles.solarNoonNote}
+        title="太陽は毎日ぴったり12時に真上に来るわけではありません"
+      >
+        今日の真太陽南中：{solarNoonText}
+        <span className={styles.solarNoonSub}>（昼の中心は真太陽南中に基づきます）</span>
+      </p>
       {/* <div className={styles.info}>
         <p className={styles.currentPeriod}>
           現在: <span className={styles.periodText}>{circleData.isDay ? '昼' : '夜'}</span> {kokuToKanji(temporalTime.koku)}刻（{getJuniShinFromKoku(temporalTime.period, temporalTime.koku)}の刻）

--- a/src/core/astronomy/constants.ts
+++ b/src/core/astronomy/constants.ts
@@ -43,3 +43,10 @@ export const ASTRONOMICAL_CONSTANTS = {
   ATMOSPHERIC_REFRACTION: 0.583,
 } as const;
 
+/**
+ * 常用薄明の伏角（寛政暦による夜明・日暮の定義）
+ * Civil twilight depression angle (Kansei calendar definition for dawn/dusk)
+ * 7°21′40″ = 太陽中心が地平線下この角度にあるときを夜明の始まり・日暮の終わりとする。
+ */
+export const CIVIL_TWILIGHT_DEPRESSION_DEG = 7 + 21 / 60 + 40 / 3600;
+

--- a/src/core/astronomy/solarNoon.ts
+++ b/src/core/astronomy/solarNoon.ts
@@ -1,0 +1,89 @@
+/**
+ * 真太陽南中（solar noon）計算
+ * Solar Noon Calculation
+ *
+ * 時計の正午（clock noon）に経度補正と均時差（EoT）を加え、
+ * 真太陽が子午線を通過する時刻を求める。
+ *
+ * Computes the moment of true solar transit (solar noon) by adding
+ * longitude correction and equation of time (EoT) to clock noon.
+ */
+
+import type { Location } from '../types';
+import { getNoonInTimeZone } from '../../utils/timezone';
+import { log } from '../../utils/debugLog';
+
+/** JST の標準子午線（度）。他 TZ は将来マッピングで拡張。 */
+const JST_STANDARD_MERIDIAN_DEG = 135;
+
+/**
+ * 指定タイムゾーンの標準子午線（度）を返す。
+ * 現状は Asia/Tokyo のみ対応。
+ */
+function getStandardMeridianDeg(timeZone: string): number {
+  if (timeZone === 'Asia/Tokyo') {
+    return JST_STANDARD_MERIDIAN_DEG;
+  }
+  return JST_STANDARD_MERIDIAN_DEG;
+}
+
+/**
+ * その日の通日 N（1–365 または 366）を、指定 TZ の暦で計算する。
+ */
+function getDayOfYear(year: number, month: number, day: number, timeZone: string): number {
+  const clockNoon = getNoonInTimeZone(year, month, day, timeZone);
+  const jan1Noon = getNoonInTimeZone(year, 1, 1, timeZone);
+  const days = (clockNoon.getTime() - jan1Noon.getTime()) / (1000 * 60 * 60 * 24);
+  return Math.round(days) + 1;
+}
+
+/**
+ * 均時差 EoT（分）を NOAA 簡易式で計算する。
+ * EoT = 真太陽時 − 平均太陽時（分）。資料によって符号定義が逆の場合があるため、実装後に松山 2/22 で検証すること。
+ */
+function getEquationOfTimeMinutes(dayOfYear: number): number {
+  const B = (2 * Math.PI * (dayOfYear - 81)) / 365;
+  return (
+    9.87 * Math.sin(2 * B) -
+    7.53 * Math.cos(B) -
+    1.5 * Math.sin(B)
+  );
+}
+
+/**
+ * 真太陽南中の瞬間を返す。
+ *
+ * 経度補正: 東に行くほど太陽は早く南中、西に行くほど遅い。
+ * 標準子午線より西（経度が小さい）なら補正は正になり、真太陽南中は時計正午より遅い。
+ *
+ * @param year - 年
+ * @param month - 月（1–12）
+ * @param day - 日
+ * @param location - 位置情報（経度・タイムゾーンを使用）
+ * @returns 真太陽南中の瞬間を表す Date
+ */
+export function getSolarNoon(
+  year: number,
+  month: number,
+  day: number,
+  location: Location
+): Date {
+  const clockNoon = getNoonInTimeZone(year, month, day, location.tz);
+  const standardMeridian = getStandardMeridianDeg(location.tz);
+
+  const longitudeCorrectionMinutes = 4 * (standardMeridian - location.lon);
+  const dayOfYear = getDayOfYear(year, month, day, location.tz);
+  const eotMinutes = getEquationOfTimeMinutes(dayOfYear);
+
+  const offsetMinutes = longitudeCorrectionMinutes - eotMinutes;
+  const solarNoon = new Date(clockNoon.getTime() + offsetMinutes * 60 * 1000);
+
+  log('solarNoon:getSolarNoon', {
+    longitudeCorrection: longitudeCorrectionMinutes,
+    EoT: eotMinutes,
+    offsetMinutes,
+    solarNoon: solarNoon.toISOString(),
+  });
+
+  return solarNoon;
+}

--- a/src/core/time-system.ts
+++ b/src/core/time-system.ts
@@ -44,31 +44,20 @@ export function getKureMutsu(sunset: Date): Date {
 /**
  * 不定時法の完全な情報を返す
  * Get complete temporal time system information
- * 
- * 日の出30分前（明け六つ）から日の入り30分後（暮れ六つ）までを昼6刻、
- * それ以外を夜6刻として分割し、現在時刻がどの刻に属するかを判定する。
- * 
- * Divides the period from 30 minutes before sunrise (ake-mutsu) to 30 minutes after sunset (kure-mutsu)
- * into 6 day koku, and the remaining period into 6 night koku, then determines which koku the current time belongs to.
- * 
- * @param sunrise - 日の出の時刻 / Sunrise time
- * @param sunset - 日の入りの時刻 / Sunset time
+ *
+ * 明け六つから暮れ六つまでを昼6刻、それ以外を夜6刻として分割し、現在時刻がどの刻に属するかを判定する。
+ * 明け六つ・暮れ六つは呼び出し側で計算（例: 伏角7°21′40″による夜明・日暮）して渡す。
+ *
+ * @param akeMutsu - 明け六つ（昼の開始時刻）/ Ake-mutsu (day start)
+ * @param kureMutsu - 暮れ六つ（昼の終了時刻）/ Kure-mutsu (day end)
  * @param now - 現在時刻 / Current time
  * @returns 不定時法の意味構造 / Temporal time system meaning structure
  */
 export function getTemporalTime(
-  sunrise: Date,
-  sunset: Date,
+  akeMutsu: Date,
+  kureMutsu: Date,
   now: Date
 ): TemporalTime {
-  // 明け六つ（日の出30分前）
-  // Ake-mutsu (30 minutes before sunrise)
-  const akeMutsu = getAkeMutsu(sunrise);
-  
-  // 暮れ六つ（日の入り30分後）
-  // Kure-mutsu (30 minutes after sunset)
-  const kureMutsu = getKureMutsu(sunset);
-  
   // 昼の時間帯（明け六つから暮れ六つまで）
   // Daytime period (from ake-mutsu to kure-mutsu)
   const dayDuration = kureMutsu.getTime() - akeMutsu.getTime();

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -150,5 +150,14 @@ export interface EdoTimeData {
    * Computed by core on the same calendar day as sunrise/sunset so the circle stays consistent when location/TZ changes.
    */
   noonForCircle: Date;
+
+  /**
+   * 真太陽南中時刻（太陽が子午線を通過する時刻）。説明表示用。
+   * True solar noon (time of solar transit). For UI explanation only.
+   */
+  solarNoon: Date;
+
+  /** 計算に使用した位置（緯度・経度・タイムゾーン）/ Location used for calculation (lat, lon, tz) */
+  location?: Location;
 }
 

--- a/src/utils/reverseGeocode.ts
+++ b/src/utils/reverseGeocode.ts
@@ -1,0 +1,68 @@
+/**
+ * 逆ジオコーディング（緯度・経度 → 地名）
+ * Reverse Geocoding (coordinates → place name)
+ *
+ * BigDataCloud の無料クライアント用 API を使用。CORS 許可のためブラウザから直接呼び出せる。
+ * Fair Use: ブラウザの Geolocation で取得した現在地の座標に限定。
+ *
+ * Uses BigDataCloud free client-side API. CORS allowed for direct browser calls.
+ */
+
+/** BigDataCloud reverse-geocode-client のレスポンス（一部） */
+interface BigDataCloudResult {
+  city?: string;
+  locality?: string;
+  principalSubdivision?: string;
+  countryName?: string;
+}
+
+const CACHE_KEY_PRECISION = 4;
+
+const cache = new Map<string, string>();
+
+function cacheKey(lat: number, lon: number): string {
+  const latR = Math.round(lat * Math.pow(10, CACHE_KEY_PRECISION));
+  const lonR = Math.round(lon * Math.pow(10, CACHE_KEY_PRECISION));
+  return `${latR},${lonR}`;
+}
+
+function buildPlaceName(data: BigDataCloudResult): string {
+  const city = data.city ?? data.locality;
+  const state = data.principalSubdivision;
+  const parts: string[] = [];
+  if (city) parts.push(city);
+  if (state && state !== city) parts.push(state);
+  if (parts.length > 0) return parts.join('・');
+  if (data.countryName) return data.countryName;
+  return '';
+}
+
+/**
+ * 緯度・経度から地名を取得する（BigDataCloud 逆ジオコーディング）
+ * 同一位置はキャッシュを返す。
+ *
+ * @param lat - 緯度 / Latitude
+ * @param lon - 経度 / Longitude
+ * @returns 地名（取得失敗時は null）/ Place name (null on failure)
+ */
+export async function reverseGeocode(lat: number, lon: number): Promise<string | null> {
+  const key = cacheKey(lat, lon);
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+
+  const url = new URL('https://api.bigdatacloud.net/data/reverse-geocode-client');
+  url.searchParams.set('latitude', String(lat));
+  url.searchParams.set('longitude', String(lon));
+  url.searchParams.set('localityLanguage', 'ja');
+
+  const res = await fetch(url.toString(), {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!res.ok) return null;
+
+  const data = (await res.json()) as BigDataCloudResult;
+  const name = buildPlaceName(data);
+  if (name) cache.set(key, name);
+  return name || null;
+}

--- a/src/utils/timeAngle.ts
+++ b/src/utils/timeAngle.ts
@@ -38,33 +38,21 @@ export function timeToAngle(time: Date, noon: Date): number {
 }
 
 /**
- * 日の出・日の入りから明け六つ・暮れ六つの角度を計算する
- * Calculate angles for ake-mutsu and kure-mutsu from sunrise and sunset
- * 
- * 日の出30分前（明け六つ）と日の入り30分後（暮れ六つ）の時刻から角度を計算する。
- * 
- * Calculates angles from times 30 minutes before sunrise (ake-mutsu) and 30 minutes after sunset (kure-mutsu).
- * 
- * @param sunrise - 日の出の時刻 / Sunrise time
- * @param sunset - 日の入りの時刻 / Sunset time
+ * 明け六つ・暮れ六つの時刻から円盤用の角度を計算する
+ * Calculate angles for ake-mutsu and kure-mutsu from their times
+ *
+ * @param akeMutsu - 明け六つの時刻 / Ake-mutsu time
+ * @param kureMutsu - 暮れ六つの時刻 / Kure-mutsu time
  * @param noon - 正午の時刻（同じ日の12時）/ Noon time (12:00 of the same day)
  * @returns 明け六つ・暮れ六つの角度 / Angles for ake-mutsu and kure-mutsu
  */
 export function calculateAkeKureAngles(
-  sunrise: Date,
-  sunset: Date,
+  akeMutsu: Date,
+  kureMutsu: Date,
   noon: Date
 ): { akeMutsuAngle: number; kureMutsuAngle: number } {
-  // 明け六つ（日の出30分前）
-  // Ake-mutsu (30 minutes before sunrise)
-  const akeMutsu = new Date(sunrise.getTime() - 30 * 60 * 1000);
   const akeMutsuAngle = timeToAngle(akeMutsu, noon);
-  
-  // 暮れ六つ（日の入り30分後）
-  // Kure-mutsu (30 minutes after sunset)
-  const kureMutsu = new Date(sunset.getTime() + 30 * 60 * 1000);
   const kureMutsuAngle = timeToAngle(kureMutsu, noon);
-  
   return { akeMutsuAngle, kureMutsuAngle };
 }
 


### PR DESCRIPTION
- 日出・日没・明け六つ・暮れ六つを真太陽南中（経度補正＋均時差）基準で計算するように変更。地域・季節によるずれを軽減。
- 不定時法円盤は時計の正午を上に固定したまま、その下に「今日の真太陽南中」時刻と短い説明を表示。
- 現在地取得のタイムアウトを 15 秒に延長し、失敗時は 1 回リトライ。取得できた時点で円盤を即時再描画。